### PR TITLE
Update kernel 6

### DIFF
--- a/kernel/src/syscall/invocation/decode/arch/aarch64.rs
+++ b/kernel/src/syscall/invocation/decode/arch/aarch64.rs
@@ -476,10 +476,6 @@ fn decode_frame_map(length: usize, frame_slot: &mut cte_t, buffer: &seL4_IPCBuff
             return exception_t::EXCEPTION_SYSCALL_ERROR;
         }
     }
-    // TODO: copy cap in the here. Not write slot when the address is not need to write.
-    frame_slot.cap.set_frame_mapped_asid(asid);
-    frame_slot.cap.set_frame_mapped_address(vaddr);
-
     let mut vspace_root_pte = PTE::new_from_pte(vspace_root);
     let base = pptr_to_paddr(frame_slot.cap.get_frame_base_ptr());
     let lu_ret = vspace_root_pte.lookup_pt_slot(vaddr);
@@ -493,6 +489,8 @@ fn decode_frame_map(length: usize, frame_slot: &mut cte_t, buffer: &seL4_IPCBuff
     }
     let pt_slot = convert_to_mut_type_ref::<PTE>(lu_ret.ptSlot as usize);
     set_thread_state(get_currenct_thread(), ThreadState::ThreadStateRestart);
+	frame_slot.cap.set_frame_mapped_asid(asid);
+    frame_slot.cap.set_frame_mapped_address(vaddr);
     return invoke_page_map(
         asid,
         frame_slot.cap.clone(),

--- a/kernel/src/syscall/invocation/decode/arch/aarch64.rs
+++ b/kernel/src/syscall/invocation/decode/arch/aarch64.rs
@@ -141,7 +141,7 @@ fn decode_page_table_invocation(
 
     if unlikely(
         pd_slot.ptBitsLeft == seL4_PageBits
-            || ptr_to_ref(pd_slot.ptSlot).get_type() != (pte_tag_t::pte_invalid) as usize,
+            || (ptr_to_ref(pd_slot.ptSlot).get_type() != (pte_tag_t::pte_invalid) as usize),
     ) {
         global_ops!(current_syscall_error._type = seL4_DeleteFirst);
         return exception_t::EXCEPTION_SYSCALL_ERROR;
@@ -683,7 +683,7 @@ fn decode_frame_map(length: usize, frame_slot: &mut cte_t, buffer: &seL4_IPCBuff
 #[allow(unused)]
 fn decode_page_table_unmap(pt_cte: &mut cte_t) -> exception_t {
     if !pt_cte.is_final_cap() {
-        debug!("RISCVPageTableUnmap: cannot unmap if more than once cap exists");
+        debug!("PageTableUnmap: cannot unmap if more than once cap exists");
         global_ops!(current_syscall_error._type = seL4_RevokeFirst);
         return exception_t::EXCEPTION_SYSCALL_ERROR;
     }

--- a/kernel/src/syscall/invocation/invoke_mmu_op.rs
+++ b/kernel/src/syscall/invocation/invoke_mmu_op.rs
@@ -111,7 +111,7 @@ pub fn invoke_page_unmap(frame_slot: &mut cte_t) -> exception_t {
         }
     }
     frame_slot.cap.set_frame_mapped_address(0);
-    frame_slot.cap.set_pt_mapped_asid(asidInvalid);
+    frame_slot.cap.set_frame_mapped_asid(asidInvalid);
     exception_t::EXCEPTION_NONE
 }
 

--- a/kernel/src/syscall/invocation/invoke_mmu_op.rs
+++ b/kernel/src/syscall/invocation/invoke_mmu_op.rs
@@ -152,7 +152,7 @@ pub fn invoke_page_map(
     // frame_slot.cap = cap;
     pt_slot.update(pte);
 
-	clean_by_va_pou(
+    clean_by_va_pou(
         convert_ref_type_to_usize(pt_slot),
         pptr_to_paddr(convert_ref_type_to_usize(pt_slot)),
     );

--- a/sel4_cspace/src/arch/aarch64/mod.rs
+++ b/sel4_cspace/src/arch/aarch64/mod.rs
@@ -85,7 +85,7 @@ plus_define_bitfield! {
             capPTMappedASID, get_pt_mapped_asid, set_pt_mapped_asid, 1, 48, 16, 0, false,
             capPTBasePtr, get_pt_base_ptr, set_pt_base_ptr, 1, 0, 48, 0, true,
             capPTIsMapped, get_pt_is_mapped, set_pt_is_mapped, 0, 48, 1, 0, false,
-            capPTMappedAddress, get_pt_mapped_address, set_pt_mapped_address, 0, 20, 28, 0, true
+            capPTMappedAddress, get_pt_mapped_address, set_pt_mapped_address, 0, 20, 28, 20, true
         },
         // new_page_directory_cap, CapTag::CapPageDirectoryCap as usize => {
         //     capPDMappedASID, get_pd_mapped_asid, set_pd_mapped_asid, 1, 48, 16, 0, false,

--- a/sel4_vspace/src/arch/aarch64/interface.rs
+++ b/sel4_vspace/src/arch/aarch64/interface.rs
@@ -323,7 +323,7 @@ pub fn unmap_page_table(asid: asid_t, vaddr: vptr_t, pt: &PTE) {
     assert!(!ptSlot.is_null());
     unsafe {
         *(ptSlot) = PTE(0);
-        ptr_to_mut(pte).update(*(ptSlot));
+        ptr_to_mut(ptSlot).update(*(pte));
     }
     invalidate_tlb_by_asid(asid);
 }
@@ -347,8 +347,8 @@ pub fn unmapPage(
     }
 
     let pte = ptr_to_mut(lu_ret.ptSlot);
-    if pte.get_type() == (pte_tag_t::pte_4k_page) as usize
-        || pte.get_type() == (pte_tag_t::pte_page) as usize
+    if !(pte.get_type() == (pte_tag_t::pte_4k_page) as usize
+        || pte.get_type() == (pte_tag_t::pte_page) as usize)
     {
         return Ok(());
     }
@@ -359,6 +359,7 @@ pub fn unmapPage(
         *(lu_ret.ptSlot) = PTE(0);
         pte.update(*(lu_ret.ptSlot));
     }
+    assert!(asid < BIT!(16));
     invalidate_tlb_by_asid(asid);
     Ok(())
 

--- a/sel4_vspace/src/arch/aarch64/interface.rs
+++ b/sel4_vspace/src/arch/aarch64/interface.rs
@@ -310,17 +310,17 @@ pub fn unmap_page_table(asid: asid_t, vaddr: vptr_t, pt: &PTE) {
     let mut pte = find_ret.vspace_root.unwrap();
     let mut level: usize = 0;
     while level < UPT_LEVELS - 1 && pte as usize != pt as *const PTE as usize {
-        level = level + 1;
         ptSlot = unsafe { pte.add(VAddr(vaddr).GET_UPT_INDEX(level)) };
         if ptr_to_mut(ptSlot).get_type() != (pte_tag_t::pte_table) as usize {
             return;
         }
         pte = paddr_to_pptr(ptr_to_mut(ptSlot).next_level_paddr()) as *mut PTE;
+        level = level + 1;
     }
     if pte as usize != pt as *const PTE as usize {
         return;
     }
-    assert!(ptSlot.is_null());
+    assert!(!ptSlot.is_null());
     unsafe {
         *(ptSlot) = PTE(0);
         ptr_to_mut(pte).update(*(ptSlot));


### PR DESCRIPTION
我在这里修复了几个page的错误，但是仍然留下了一个TODO
TODO：发现廖东海写的关于那些东西的宏定义，最终实现的位偏移存在问题（也有可能是最后填充数值的时候和宏定义期望的方式对不上），在正常情况下不会触发，但是当数值位数超限的时候会导致截断问题。我只是更改了set_pt_mapped_address的值让他看上去正常，需要按照他实现的方式，更改所有的offset和shift的值。